### PR TITLE
Automated build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: c
+dist: trusty
+sudo: required
+install: sudo apt-get -y update && sudo apt-get install libgtk-3-dev
+script: rm -f tek4010 && make

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 LIBS = `pkg-config --libs gtk+-3.0`
 
-CFLAGS = `pkg-config --cflags gtk+-3.0`
+CFLAGS = -std=c99 `pkg-config --cflags gtk+-3.0`
 
 all: tek4010
 


### PR DESCRIPTION
Hello @rricharz,

This pull request enables automated building with Travis CI.  Testing could be added to this.

The version of GCC provided by Travis needs the option `-std=c99`, or else it will complain about things like `for (int i = 0;`.