### PR TITLE
Fix warnings.

### DIFF
--- a/tek4010.c
+++ b/tek4010.c
@@ -38,6 +38,8 @@
                                 
 #define PI2 6.283185307
 
+#define _GNU_SOURCE
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h> 


### PR DESCRIPTION
Fix warnings about popen, pclose, fdopen, and usleep not being declared.

Some versions of glibc need _GNU_SOURCE defined to supply the declarations.