### PR TITLE
Cygwin defines FIONREAD in <sys/socket.h>.

### DIFF
--- a/tube.c
+++ b/tube.c
@@ -48,6 +48,9 @@
 #include <sys/time.h>
 #include <locale.h>
 #include <pwd.h>
+#ifndef FIONREAD
+#include <sys/socket.h>
+#endif
 
 #include "main.h"
 #include "tube.h"


### PR DESCRIPTION
This makes it possible to build on Cygwin.