### PR TITLE
Fix makefile to support sed command on macOS

### DIFF
--- a/makefile
+++ b/makefile
@@ -4,9 +4,12 @@ CFLAGS = -std=c99 `pkg-config --cflags gtk+-3.0`
 
 all: tek4010
 
-tek4010: src/help.txt src/main.c src/main.h src/tube.c src/tube.h src/tek4010.c src/ards.c
-	sed 's/\"/\\\"/g; s/$$/\\n"/; s/^/"/; 1s/^/const char *helpStr =\n/; $$a;' src/help.txt > src/help.h
+tek4010: src/help.h src/main.c src/main.h src/tube.c src/tube.h src/tek4010.c src/ards.c
 	$(CC) -o tek4010 src/main.c src/tube.c src/tek4010.c src/ards.c $(LIBS) $(CFLAGS)
+
+src/help.h: src/help.txt
+	sed 's/\"/\\\"/g; s/$$/\\n"/; s/^/"/; 1s/^/const char *helpStr =\n/; $$a\
+;' src/help.txt > src/help.h
 
 install: tek4010
 	./install

--- a/makefile
+++ b/makefile
@@ -8,8 +8,8 @@ tek4010: src/help.h src/main.c src/main.h src/tube.c src/tube.h src/tek4010.c sr
 	$(CC) -o tek4010 src/main.c src/tube.c src/tek4010.c src/ards.c $(LIBS) $(CFLAGS)
 
 src/help.h: src/help.txt
-	sed 's/\"/\\\"/g; s/$$/\\n"/; s/^/"/; 1s/^/const char *helpStr =\n/; $$a\
-;' src/help.txt > src/help.h
+	sed 's/\"/\\\"/g; s/$$/\\n"/; s/^/"/; 1s/^/const char *helpStr =\n/;' src/help.txt > src/help.h
+	echo ";" >> src/help.h
 
 install: tek4010
 	./install


### PR DESCRIPTION
The sed append command notation in the makefile can only be used with gnu sed, so macOS sed will give an error, "command a expects \ followed by text".
I have corrected it to the old way of writing.
It is a little ugly, but the append command requires '\' and real new line character.

I've tested this modification on ubuntu 22.04 and macOS 13.6.