### PR TITLE
Make sed line FreeBSD compatible

### DIFF
--- a/makefile
+++ b/makefile
@@ -5,7 +5,8 @@ CFLAGS = -std=c99 `pkg-config --cflags gtk+-3.0`
 all: tek4010
 
 tek4010: src/help.txt src/main.c src/main.h src/tube.c src/tube.h src/tek4010.c src/ards.c
-	sed 's/\"/\\\"/g; s/$$/\\n"/; s/^/"/; 1s/^/const char *helpStr =\n/; $$a;' src/help.txt > src/help.h
+	sed 's/\"/\\\"/g; s/$$/\\n"/; s/^/"/; 1s/^/const char *helpStr =\n/;' src/help.txt > src/help.h
+	echo ";" >> src/help.h
 	$(CC) -o tek4010 src/main.c src/tube.c src/tek4010.c src/ards.c $(LIBS) $(CFLAGS)
 
 install: tek4010


### PR DESCRIPTION
The recent addition of help.h to the build uses a sed command that is apparently incompatible with FreeBSD's sed.  It pukes with complaints about the use of "$$" and the a command.  

Since the entire purpose of this part of the sed command is to add a semicolon at the end of the help string, I have replaced it with a simple echo of ";" appended to help.h.

This PR is offered as an alternative, even more portable approach than #45.  The approach there only works with GNU Make and fails with BSD Make.