### PR TITLE
Standardize Whitespace in Source Code

### DIFF
--- a/apl/apltest.c
+++ b/apl/apltest.c
@@ -7,39 +7,39 @@
 
 int main (int argc, char *argv[])
 {
-	int ch, i;
+        int ch, i;
 
-	printf("\nStandard character set:\n");
+        printf("\nStandard character set:\n");
         printf("    ");
-	for (i = 0; i < 10; i++) printf("%1d ",i);        
-	for (ch = 30; ch <= 126; ch++) {
-		if ((ch % 10) == 0) {
-			printf("\n%03d ", ch);
-		}
-		if (ch > 32)
-			printf("%c ", ch);
-		else
-			printf("  ");
-	}
-	printf("\n");
+        for (i = 0; i < 10; i++) printf("%1d ",i);
+        for (ch = 30; ch <= 126; ch++) {
+                if ((ch % 10) == 0) {
+                        printf("\n%03d ", ch);
+                }
+                if (ch > 32)
+                        printf("%c ", ch);
+                else
+                        printf("  ");
+        }
+        printf("\n");
 
         printf("\nTektronix APL character set:\n");
-	putchar(27); putchar(14);  // switch to alternative character set
-	printf("    ");
-	for (i = 0; i < 10; i++) printf("%1d ",i); 
-	for (ch = 30; ch <= 126; ch++) {
-		if ((ch % 10) == 0) {
-			printf("\n%03d ", ch);
-		}
-		if (ch >32)
-			printf("%c ", ch);
-		else
-			printf("  ");
-	}
+        putchar(27); putchar(14);  // switch to alternative character set
+        printf("    ");
+        for (i = 0; i < 10; i++) printf("%1d ",i);
+        for (ch = 30; ch <= 126; ch++) {
+                if ((ch % 10) == 0) {
+                        printf("\n%03d ", ch);
+                }
+                if (ch >32)
+                        printf("%c ", ch);
+                else
+                        printf("  ");
+        }
         printf("\n\noverstrike test");
         putchar(62); putchar(32);
         putchar(79); putchar(8); putchar(63); putchar(32);
         putchar(76); putchar(8); putchar(43);
-	putchar(27); putchar(15);  // switch back to standard character set
-	printf("\n");
+        putchar(27); putchar(15);  // switch back to standard character set
+        printf("\n");
 }

--- a/src/ards.c
+++ b/src/ards.c
@@ -1,32 +1,32 @@
 /*
  * ards.c
- * 
+ *
  * ARDS option for tek4010 graphics emulator
- * 
+ *
  * Copyright 2019  Lars Brinkhoff
- * 
+ *
  * https://github.com/rricharz/Tek4010
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
  * MA 02110-1301, USA.
  *
  */
- 
+
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h> 
+#include <string.h>
 #include <termios.h>
 #include <sys/ioctl.h>
 #include <sys/types.h>
@@ -77,40 +77,40 @@ static void draw_vector (cairo_t *cr, cairo_t *cr2)
 
 void ards_draw(cairo_t *cr, cairo_t *cr2, int first)
 // draw onto the main window using cairo
-// cr is used for persistent drawing, cr2 for temporary drawing 
+// cr is used for persistent drawing, cr2 for temporary drawing
 
-{	
+{
         int ch;
-        
+
         refreshCount++;  // to calculate the average refresh rate
-               
+
         if (first) {
                 first = 0;
                 efactor = windowWidth / 1080.0;
                 // fprintf (stderr, "efactor: %0.2f\n", efactor);
-                refresh_interval = 50;        
+                refresh_interval = 50;
                 tube_changeCharacterSize(cr, cr2, 80, 50, efactor * 1.1);
-                
+
         }
-        
+
         startPaintTime = tube_mSeconds(); // start to measure time for this draw operation
 
         showCursor = 1;
         isBrightSpot = 0;
-        
+
         // clear the second surface
         tube_clearSecond(cr2);
-        
+
         // clear persistent surface, if necessary
         if (tube_doClearPersistent) {
                 tube_clearPersistent(cr,cr2);
         }
-        
+
         tube_setupPainting(cr, cr2, STANDARD_FONT);
-        
+
         do {
                 ch = tube_getInputChar();
-                
+
                 if (tube_isInput() == 0) {
                 }
 
@@ -118,123 +118,123 @@ void ards_draw(cairo_t *cr, cairo_t *cr2, int first)
                         return;         // no char available, need to allow for updates
                 }
 
-		//fprintf (stderr, "\n[INPUT %03o [%d/%d]]", ch, mode, args);
+                //fprintf (stderr, "\n[INPUT %03o [%d/%d]]", ch, mode, args);
 
-		if (args > 0) {
-		  data[--args] = ch;
-		}
+                if (args > 0) {
+                        data[--args] = ch;
+                }
 
-		switch (ch) {
-		case 007:
-		  mode = 0;
-		  args = 0;
-		  break;
-		case 010:
-		  mode = 0;
-		  args = 0;
-		  x0 -= hDotsPerChar;
-		  break;
-		case 012:
-		  mode = 0;
-		  args = 0;
-		  y0 -= vDotsPerChar;
-		  break;
-		case 014:
-		  mode = 0;
-		  args = 0;
-		  x0 = -485;
-		  y0 = 450;
-		  tube_clearPersistent(cr, cr2);
-		  break;
-		case 015:
-		  mode = 0;
-		  args = 0;
-		  x0 = -479;
-		  break;
-		case 034:
-		  mode = 0;
-		  args = 0;
-		  break;
-		case 035:
-		  //fprintf (stderr, "[POINT]");
-		  mode = 1;
-		  args = 4;
-		  break;
-		case 036:
-		  //fprintf (stderr, "[E VEC]");
-		  mode = 2;
-		  args = 4;
-		  break;
-		case 037:
-		  //fprintf (stderr, "[S VEC]");
-		  mode = 3;
-		  args = 2;
-		  break;
-		default:
-		  if (args == 0) {
-		    switch (mode) {
-		    case 0:
-		      //fprintf (stderr, "[SYMBOL %c @ %d, %d]", ch, x0, y0);
-		      draw_char (cr, cr2, ch);
-		      break;
-		    case 1:
-		      args = 4;
-		      x0 = (data[3] & 076) >> 1;
-		      x0 |= (data[2] & 037) << 5;
-		      if (data[3] & 1)
-			x0 = -x0;
-		      y0 = (data[1] & 076) >> 1;
-		      y0 |= (data[0] & 037) << 5;
-		      if (data[1] & 1)
-			y0 = -y0;
-		      //fprintf (stderr, "[POINT @ %d, %d]", x0, y0);
-		      break;
-		    case 2:
-		      args = 4;
-		      x2 = (data[3] & 076) >> 1;
-		      x2 |= (data[2] & 037) << 5;
-		      if (data[3] & 1)
-			x2 = -x2;
-		      x2 += x0;
-		      y2 = (data[1] & 076) >> 1;
-		      y2 |= (data[0] & 037) << 5;
-		      if (data[1] & 1)
-			y2 = -y2;
-		      y2 += y0;
-		      //fprintf (stderr, "[E VEC @ %d,%d - %d,%d]", x0, y0, x2, y2);
-		      if (data[2] & 040)
-			; //fprintf (stderr, "[INVISIBLE]");
-		      else
-			draw_vector(cr, cr2);
-		      if (data[0] & 040)
-			; //fprintf (stderr, "[DOTTED]");
-		      x0 = x2;
-		      y0 = y2;
-		      break;
-		    case 3:
-		      args = 2;
-		      x2 = (data[1] & 076) >> 1;
-		      if (data[1] & 1)
-			x2 = -x2;
-		      x2 += x0;
-		      y2 = (data[0] & 076) >> 1;
-		      if (data[0] & 1)
-			y2 = -y2;
-		      y2 += y0;
-		      draw_vector(cr, cr2);
-		      //fprintf (stderr, "[S VEC @ %d,%d - %d,%d]", x0, y0, x2, y2);
-		      x0 = x2;
-		      y0 = y2;
-		      break;
-		    }
-		  }
-		  break;
-		}
+                switch (ch) {
+                case 007:
+                        mode = 0;
+                        args = 0;
+                        break;
+                case 010:
+                        mode = 0;
+                        args = 0;
+                        x0 -= hDotsPerChar;
+                        break;
+                case 012:
+                        mode = 0;
+                        args = 0;
+                        y0 -= vDotsPerChar;
+                        break;
+                case 014:
+                        mode = 0;
+                        args = 0;
+                        x0 = -485;
+                        y0 = 450;
+                        tube_clearPersistent(cr, cr2);
+                        break;
+                case 015:
+                        mode = 0;
+                        args = 0;
+                        x0 = -479;
+                        break;
+                case 034:
+                        mode = 0;
+                        args = 0;
+                        break;
+                case 035:
+                        //fprintf (stderr, "[POINT]");
+                        mode = 1;
+                        args = 4;
+                        break;
+                case 036:
+                        //fprintf (stderr, "[E VEC]");
+                        mode = 2;
+                        args = 4;
+                        break;
+                case 037:
+                        //fprintf (stderr, "[S VEC]");
+                        mode = 3;
+                        args = 2;
+                        break;
+                default:
+                        if (args == 0) {
+                                switch (mode) {
+                                case 0:
+                                        //fprintf (stderr, "[SYMBOL %c @ %d, %d]", ch, x0, y0);
+                                        draw_char (cr, cr2, ch);
+                                        break;
+                                case 1:
+                                        args = 4;
+                                        x0 = (data[3] & 076) >> 1;
+                                        x0 |= (data[2] & 037) << 5;
+                                        if (data[3] & 1)
+                                                x0 = -x0;
+                                        y0 = (data[1] & 076) >> 1;
+                                        y0 |= (data[0] & 037) << 5;
+                                        if (data[1] & 1)
+                                                y0 = -y0;
+                                        //fprintf (stderr, "[POINT @ %d, %d]", x0, y0);
+                                        break;
+                                case 2:
+                                        args = 4;
+                                        x2 = (data[3] & 076) >> 1;
+                                        x2 |= (data[2] & 037) << 5;
+                                        if (data[3] & 1)
+                                                x2 = -x2;
+                                        x2 += x0;
+                                        y2 = (data[1] & 076) >> 1;
+                                        y2 |= (data[0] & 037) << 5;
+                                        if (data[1] & 1)
+                                                y2 = -y2;
+                                        y2 += y0;
+                                        //fprintf (stderr, "[E VEC @ %d,%d - %d,%d]", x0, y0, x2, y2);
+                                        if (data[2] & 040)
+                                                ; //fprintf (stderr, "[INVISIBLE]");
+                                        else
+                                                draw_vector(cr, cr2);
+                                        if (data[0] & 040)
+                                                ; //fprintf (stderr, "[DOTTED]");
+                                        x0 = x2;
+                                        y0 = y2;
+                                        break;
+                                case 3:
+                                        args = 2;
+                                        x2 = (data[1] & 076) >> 1;
+                                        if (data[1] & 1)
+                                                x2 = -x2;
+                                        x2 += x0;
+                                        y2 = (data[0] & 076) >> 1;
+                                        if (data[0] & 1)
+                                                y2 = -y2;
+                                        y2 += y0;
+                                        draw_vector(cr, cr2);
+                                        //fprintf (stderr, "[S VEC @ %d,%d - %d,%d]", x0, y0, x2, y2);
+                                        x0 = x2;
+                                        y0 = y2;
+                                        break;
+                                }
+                        }
+                        break;
+                }
         }
         while (((tube_mSeconds() - startPaintTime) < refresh_interval));
-        
+
         // display cursor
-        
+
         if (showCursor && (tube_isInput() == 0)) tube_doCursor(cr2);
-        
+
 }

--- a/src/main.c
+++ b/src/main.c
@@ -2,33 +2,33 @@
  *
  * main.c
  * provides a simple framework for basic drawing with cairo and gtk+ 3.0
- * 
+ *
  * Version adapted for tek4010
- * 
+ *
  * Copyright 2016,2019  rricharz
  *
  * https://github.com/rricharz/Tek4010
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
  * MA 02110-1301, USA.
- * 
- * 
+ *
+ *
  */
- 
+
 #define TIME_INTERVAL       35              // time interval for timer function in msec (after last refresh)
- 
+
 #define GDK_DISABLE_DEPRECATION_WARNINGS
 
 #include <stdio.h>
@@ -63,18 +63,18 @@ extern int tube_doClearPersistent;
 
 static void do_drawing(cairo_t *, GtkWidget *);
 
-static gboolean on_draw_event(GtkWidget *widget, cairo_t *cr, 
+static gboolean on_draw_event(GtkWidget *widget, cairo_t *cr,
     gpointer user_data)
-{  
-	do_drawing(cr, widget);  
-	return FALSE;
+{
+        do_drawing(cr, widget);
+        return FALSE;
 }
 
 static gboolean on_timer_event(GtkWidget *widget)
 {
-	if (tube_on_timer_event())
+        if (tube_on_timer_event())
                 gtk_widget_queue_draw(widget);
-	return TRUE;
+        return TRUE;
 }
 
 static gboolean clicked(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
@@ -86,22 +86,22 @@ static gboolean clicked(GtkWidget *widget, GdkEventButton *event, gpointer user_
 
 static void on_quit_event()
 {
-	tube_quit();
-	gtk_main_quit();
+        tube_quit();
+        gtk_main_quit();
         exit(0);
 }
 
 static void do_drawing(cairo_t *cr, GtkWidget *widget)
 {
         static cairo_surface_t *permanent_surface, *temporary_surface;
-        
+
         g_source_remove(global_timeout_ref);    // stop timer, in case do_drawing takes too long
-	
-	if (global_firstcall) {
+
+        if (global_firstcall) {
                 // force aspect ratio by making black stripes at left and right, or top and bottom
                 gtk_window_get_size(GTK_WINDOW(window), &windowWidth, &windowHeight);
                 // gtk_window_set_resizable(GTK_WINDOW(window), 0); // do not allow further resizing
-                
+
                 if ((windowWidth != 1024) || (windowHeight != 768)) {
                     if (windowWidth > (int)((double)windowHeight * aspectRatio + 0.5)) {
                         windowWidthOffset = (windowWidth - (int)((double)windowHeight * aspectRatio)) / 2;
@@ -114,19 +114,19 @@ static void do_drawing(cairo_t *cr, GtkWidget *widget)
                 }
                 printf("Window dimensions: %d x %d\n", windowWidth, windowHeight);
 
-		permanent_surface = cairo_surface_create_similar(cairo_get_target(cr),
-			CAIRO_CONTENT_COLOR, windowWidth, windowHeight);
+                permanent_surface = cairo_surface_create_similar(cairo_get_target(cr),
+                        CAIRO_CONTENT_COLOR, windowWidth, windowHeight);
                 temporary_surface = cairo_surface_create_similar(cairo_get_target(cr),
-			CAIRO_CONTENT_COLOR_ALPHA, windowWidth, windowHeight);
-                        
+                        CAIRO_CONTENT_COLOR_ALPHA, windowWidth, windowHeight);
+
                 if (argHideCursor) { // hide cursor (does not allow GIN mode)
                         GdkCursor* Cursor = gdk_cursor_new(GDK_BLANK_CURSOR);
                         GdkWindow* win = gtk_widget_get_window(window);
                         gdk_window_set_cursor((win), Cursor);
                 }
-	}
-	
-	cairo_t *permanent_cr = cairo_create(permanent_surface);
+        }
+
+        cairo_t *permanent_cr = cairo_create(permanent_surface);
         cairo_t *temporary_cr = cairo_create(temporary_surface);
         if ((permanent_cr == NULL) || (temporary_cr == NULL)) {
                 printf("Cannot create drawing surfaces\n");
@@ -136,10 +136,10 @@ static void do_drawing(cairo_t *cr, GtkWidget *widget)
                 ards_draw(permanent_cr, temporary_cr, global_firstcall);
         else
                 tek4010_draw(permanent_cr, temporary_cr, global_firstcall);
-	global_firstcall = FALSE;
+        global_firstcall = FALSE;
 
-	cairo_set_source_surface(cr, permanent_surface, windowWidthOffset, windowHeightOffset);
-	cairo_paint(cr);
+        cairo_set_source_surface(cr, permanent_surface, windowWidthOffset, windowHeightOffset);
+        cairo_paint(cr);
         if (argFast) {
                 cairo_set_source_surface(cr, temporary_surface, windowWidthOffset, windowHeightOffset);
                 cairo_paint(cr);
@@ -150,8 +150,8 @@ static void do_drawing(cairo_t *cr, GtkWidget *widget)
                 cairo_paint(cr);
                 cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
         }
-         
-	cairo_destroy(permanent_cr);
+
+        cairo_destroy(permanent_cr);
         cairo_destroy(temporary_cr);
         global_timeout_ref = g_timeout_add(TIME_INTERVAL, (GSourceFunc) on_timer_event,
                                                 (gpointer) window);
@@ -161,16 +161,16 @@ static void on_key_press(GtkWidget *widget, GdkEventKey *event, gpointer user_da
 {
         int ch;
         // printf("key pressed, state =%04X, keyval=%04X, isGinMode = %d\r\n", event->state, event->keyval, isGinMode);
-        
+
         if ((event->keyval == 0xFF50) ||        // "home" key
                 (event->keyval == 0xFF55) ||    // "page up" key
-                (event->keyval == 0xFF56))      // "page down" key        
+                (event->keyval == 0xFF56))      // "page down" key
         {
                 tube_doClearPersistent = 1;
                 gtk_widget_queue_draw(widget);
                 return;
         }
-        
+
         if (event->keyval == 0x8BF) {           // "option b" sends break code to target
                 if (putKeys) {
                 printf("sending break code\n");
@@ -178,7 +178,7 @@ static void on_key_press(GtkWidget *widget, GdkEventKey *event, gpointer user_da
                 putc(0xF3, putKeys);
                 }
         }
-        
+
         // control keys
         else if ((event->keyval >= 0xFF00) && (event->keyval <= 0xFF1F))
                 ch = event->keyval & 0x1F;
@@ -206,29 +206,29 @@ static void on_key_press(GtkWidget *widget, GdkEventKey *event, gpointer user_da
                         aplMode = 0;
                         // printf("Setting APL mode to 0 from keyboard\n");
                         return;
-                }                
+                }
                 else
                         ch = event->keyval & 0x1F;
         }
         else if (event->keyval == 0xFF52) ch = 16;  // arrow up for history up
         else if (event->keyval == 0xFF54) ch = 14;  // arrow down for history down
-        
+
         else if ((event->state & GDK_MOD1_MASK) && (aplMode)) {   // alt key
                 printf("alt key, ch = %4X\n", event->keyval & 0x7F);
                 ch = (event->keyval & 0x7F) + 128;
         }
-        
+
         // normal keys
         else if ((event->keyval >= 0x0020) && (event->keyval <= 0x007F))
                 ch = event->keyval & 0x7F;
-                
+
         else return;
-        
+
         if (isGinMode) { // need to pass key to GIN mode handling, not to child process
                 isGinMode = ch;
                 gtk_widget_queue_draw(widget);
         }
-                
+
         else if (putKeys) {
                 // pipe key to child process, if stream open
                 if (aplMode) {
@@ -246,18 +246,18 @@ static void on_key_press(GtkWidget *widget, GdkEventKey *event, gpointer user_da
 
 int main (int argc, char *argv[])
 {
-	GtkWidget *darea;
-        
+        GtkWidget *darea;
+
         int askWindowWidth;
         int askWindowHeight;
-        
+
         tube_init(argc, argv);
-        
+
         if (argARDS) {
                 askWindowWidth = 1080;
-                askWindowHeight = 1414;                
+                askWindowHeight = 1414;
         }
-        
+
         else if (argFull) {
                 askWindowWidth = 4096;
                 askWindowHeight = 3120;
@@ -266,15 +266,15 @@ int main (int argc, char *argv[])
                 askWindowWidth = 1024;
                 askWindowHeight = 780;
         }
-        
-        aspectRatio = (double)askWindowWidth / (double)askWindowHeight;
-          
-	gtk_init(&argc, &argv);
-	
-	global_firstcall = TRUE;
 
-	window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-        
+        aspectRatio = (double)askWindowWidth / (double)askWindowHeight;
+
+        gtk_init(&argc, &argv);
+
+        global_firstcall = TRUE;
+
+        window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+
         // set the background color
         GdkColor color;
         color.red   = 0;
@@ -282,31 +282,31 @@ int main (int argc, char *argv[])
         color.blue  = 0;
         gtk_widget_modify_bg(window, GTK_STATE_NORMAL, &color);
 
-	darea = gtk_drawing_area_new();
-	gtk_container_add(GTK_CONTAINER(window), darea);
-	gtk_widget_add_events(window, GDK_BUTTON_PRESS_MASK);
+        darea = gtk_drawing_area_new();
+        gtk_container_add(GTK_CONTAINER(window), darea);
+        gtk_widget_add_events(window, GDK_BUTTON_PRESS_MASK);
         gtk_widget_add_events(window, GDK_KEY_PRESS_MASK);
 
         gtk_widget_set_events(darea,gtk_widget_get_events(darea) | GDK_BUTTON_PRESS_MASK | GDK_POINTER_MOTION_MASK);
-	g_signal_connect(G_OBJECT(darea),  "draw",  G_CALLBACK(on_draw_event), NULL);
-	g_signal_connect(G_OBJECT(darea), "destroy", G_CALLBACK(on_quit_event), NULL);
-	g_signal_connect(G_OBJECT(darea), "button-press-event", G_CALLBACK(clicked), NULL);
+        g_signal_connect(G_OBJECT(darea),  "draw",  G_CALLBACK(on_draw_event), NULL);
+        g_signal_connect(G_OBJECT(darea), "destroy", G_CALLBACK(on_quit_event), NULL);
+        g_signal_connect(G_OBJECT(darea), "button-press-event", G_CALLBACK(clicked), NULL);
         g_signal_connect(G_OBJECT(window), "key_press_event", G_CALLBACK(on_key_press), NULL);
-        
+
         GdkScreen *screen = gtk_window_get_screen(GTK_WINDOW(window));
-	int screenWidth = gdk_screen_get_width(screen);
-	int screenHeight = gdk_screen_get_height(screen);
-	printf("Screen dimensions: %d x %d\n", screenWidth, screenHeight);
-        
-        if (argFull) {        
+        int screenWidth = gdk_screen_get_width(screen);
+        int screenHeight = gdk_screen_get_height(screen);
+        printf("Screen dimensions: %d x %d\n", screenWidth, screenHeight);
+
+        if (argFull) {
                 // DISPLAY UNDECORATED FULL SCREEN WINDOW
-		gtk_window_set_decorated(GTK_WINDOW(window), FALSE);
-		gtk_window_fullscreen(GTK_WINDOW(window));
-		gtk_window_set_keep_above(GTK_WINDOW(window), FALSE);
-		windowWidth  = screenWidth;
-		windowHeight = screenHeight;
+                gtk_window_set_decorated(GTK_WINDOW(window), FALSE);
+                gtk_window_fullscreen(GTK_WINDOW(window));
+                gtk_window_set_keep_above(GTK_WINDOW(window), FALSE);
+                windowWidth  = screenWidth;
+                windowHeight = screenHeight;
         }
- 
+
         else {
                 // DISPLAY DECORATED WINDOW
                 if (argFullV || (askWindowHeight > (screenHeight - BORDER))) {
@@ -316,23 +316,23 @@ int main (int argc, char *argv[])
                 gtk_window_set_decorated(GTK_WINDOW(window), TRUE);
                 gtk_window_set_default_size(GTK_WINDOW(window), askWindowWidth, askWindowHeight);
                 windowWidth  = askWindowWidth;
-                windowHeight = askWindowHeight;                
+                windowHeight = askWindowHeight;
         }
         // printf("Requested window dimensions: %d x %d\n", windowWidth, windowHeight);
- 
+
         if (TIME_INTERVAL > 0) {
-		// Add timer event
-		// Register the timer and set time in mS.
-		// The timer_event() function is called repeatedly until it returns FALSE. 
-		global_timeout_ref = g_timeout_add(TIME_INTERVAL, (GSourceFunc) on_timer_event,
+                // Add timer event
+                // Register the timer and set time in mS.
+                // The timer_event() function is called repeatedly until it returns FALSE.
+                global_timeout_ref = g_timeout_add(TIME_INTERVAL, (GSourceFunc) on_timer_event,
                                                 (gpointer) window);
-	}
+        }
 
-	gtk_window_set_title(GTK_WINDOW(window), windowName);
-	
-	gtk_widget_show_all(window);
+        gtk_window_set_title(GTK_WINDOW(window), windowName);
 
-	gtk_main();
+        gtk_widget_show_all(window);
 
-	return 0;
+        gtk_main();
+
+        return 0;
 }


### PR DESCRIPTION
I've noticed that the source code files include a mix of whitespace and tab characters, along with extra spaces at the end of lines. To improve readability and maintain consistency, I suggest we standardize the use of whitespace characters and remove any trailing spaces.

* This commit is purely cosmetic and 'git diff -b' does not show any changes.
* I have confirmed  'tek4010 demos/demo.sh' shows all .plt files as before on ubuntu 22.04 and macOS 13.6.
