### PR TITLE
Make src/help.h ignored by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,4 @@ Mkfile.old
 dkms.conf
 
 # Temporary files
-src/help.txt
+src/help.h


### PR DESCRIPTION
src/help.h is generated from src/help.txt, so it shouldn't be tracked by git. But src/help.txt *should* be.

This commit makes it so.

This simply redoes what commit 4c17c12 did, and which got undone in commit 0c1b350.

