### PR TITLE
Fix clang warning regarding printf

### DIFF
--- a/src/tube.c
+++ b/src/tube.c
@@ -300,7 +300,7 @@ void tube_init(int argc, char* argv[])
         }
 
         if ((strcmp(argv[firstArg],"-h") == 0) || (strcmp(argv[firstArg],"--help") == 0)){
-                printf(helpStr);
+                printf("%s",helpStr);
                 exit(0);
         }
 


### PR DESCRIPTION
In tube.c, a use of "printf(helpstr)" was flagged by clang (the default compiler on FreeBSD and macOS) as potentially insecure.  The insecurity of this is probably insignificant, but fixing it removes a warning from compilation.

The warning is:
```
   src/tube.c:303:24: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
  303 |                 printf(helpStr);
      |                        ^~~~~~~
src/tube.c:303:24: note: treat the string as an argument to avoid this
  303 |                 printf(helpStr);
      |                        ^
```
All that need be done is to provide a format string that is a string literal, with helpStr being the string to print instead of the format string.