### PR TITLE
Added _XOPEN_SOURCE macro

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 LIBS = `pkg-config --libs gtk+-3.0`
 
-CFLAGS = -std=c99 `pkg-config --cflags gtk+-3.0`
+CFLAGS = -std=c99 `pkg-config --cflags gtk+-3.0` -D_XOPEN_SOURCE
 
 all: tek4010
 


### PR DESCRIPTION
`fileno` function used in main.c is a POSIX extension, so specifying the macro is necessary to compile using C99 mode

I wasn't able to compile tek4010 without this. I am using gcc version 15.3.0